### PR TITLE
vold: Fix cryptfs changepw parsing

### DIFF
--- a/CryptCommandListener.cpp
+++ b/CryptCommandListener.cpp
@@ -262,13 +262,14 @@ int CryptCommandListener::CryptfsCmd::runCommand(SocketClient *cli,
         rc = cryptfs_enable_file();
     } else if (subcommand == "changepw") {
         const char* syntax = "Usage: cryptfs changepw "
-                             "default|password|pin|pattern [currentpasswd] "
-                             "default|password|pin|pattern [newpasswd]";
+                             "default|password|pin|pattern [[currentpasswd] newpasswd]";
         const char* password;
-        const char* currentpassword;
-        if (argc == 4) {
-            currentpassword = "";
+        const char* currentpassword = "";
+        if (argc == 3) {
             password = "";
+        }
+        else if (argc == 4) {
+            password = argv[3];
         } else if (argc == 5) {
             currentpassword = argv[3];
             password = argv[4];


### PR DESCRIPTION
External tools may expect original AOSP usage.  Restore that behavior
for 3 and 4 argument invocations.  HW FDE extensions are indicated by
passing 5 arguments.

BUGBASH-1286

Change-Id: I1719f05c57e0e293720b5c1383c9b21b5f958aec